### PR TITLE
Check for solr before running setup in test action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,10 @@ on:
       tag:
         required: false
         type: string
+      solr:
+        required: false
+        type: boolean
+        default: true
   workflow_call:
     inputs:
       worker:
@@ -16,6 +20,10 @@ on:
       tag:
         required: false
         type: string
+      solr:
+        required: false
+        type: boolean
+        default: true
 env:
   REGISTRY: ghcr.io
 
@@ -74,6 +82,7 @@ jobs:
           "solrcloud-upload-configset.sh /app/samvera/hyrax-webapp/solr/config &&
           SOLR_COLLECTION_NAME=hydra-test solrcloud-assign-configset.sh &&
           solrcloud-assign-configset.sh"
+        if: ${{ inputs.solr }}
       - name: Setup db
         run: >-
           docker-compose exec -T web bash -c

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Setup db
         run: >-
           docker-compose exec -T web bash -c
-          "RAILS_ENV=test bundle exec rake db:schema:load db:migrate"
+          "RAILS_ENV=test bundle exec rake db:create db:schema:load db:migrate"
       - name: Run Specs
         env:
           # Specifies how many jobs you would like to run in parallel,

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,10 +8,6 @@ on:
       tag:
         required: false
         type: string
-      solr:
-        required: false
-        type: boolean
-        default: true
   workflow_call:
     inputs:
       worker:
@@ -20,10 +16,6 @@ on:
       tag:
         required: false
         type: string
-      solr:
-        required: false
-        type: boolean
-        default: true
 env:
   REGISTRY: ghcr.io
 
@@ -76,13 +68,17 @@ jobs:
         if: ${{ inputs.worker }}
       - name: Start containers
         run: docker-compose up -d web
-      - name: Setup solr
-        run: >-
-          docker-compose exec -T web bash -c
-          "solrcloud-upload-configset.sh /app/samvera/hyrax-webapp/solr/config &&
-          SOLR_COLLECTION_NAME=hydra-test solrcloud-assign-configset.sh &&
-          solrcloud-assign-configset.sh"
-        if: ${{ inputs.solr }}
+      - name: Check for and setup Solr if needed
+        run: |
+          if [ -d solr ]
+          then
+            docker-compose exec -T web bash -c
+            "solrcloud-upload-configset.sh /app/samvera/hyrax-webapp/solr/config &&
+            SOLR_COLLECTION_NAME=hydra-test solrcloud-assign-configset.sh &&
+            solrcloud-assign-configset.sh"
+          else
+            echo "No solr directory found, skipping..."
+          fi
       - name: Setup db
         run: >-
           docker-compose exec -T web bash -c


### PR DESCRIPTION
Not all projects use Solr. Before setting up Solr to run tests, check for a `./solr` directory; only projects that have one use Solr. 

Also, ensure the test database exists before running migrations. 