### PR TITLE
Allow for RSpec command override

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,10 @@ on:
       tag:
         required: false
         type: string
+      rspec_cmd:
+        required: false
+        type: string
+        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
   workflow_call:
     inputs:
       worker:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,9 @@ jobs:
           # Use the index from matrix as an environment variable
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
         continue-on-error: true
-        run: docker-compose exec -T web sh -c ${{ inputs.rspec_cmd }}
+        run: >-
+          docker-compose exec -T web sh -c
+          ${{ inputs.rspec_cmd }}
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,7 +94,7 @@ jobs:
         run: >-
           docker-compose exec -T web sh -c
           "gem install semaphore_test_boosters &&
-          rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
+          /usr/local/rvm/gems/default/wrappers/rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -101,7 +101,7 @@ jobs:
         continue-on-error: true
         run: >-
           docker-compose exec -T web sh -c
-          ${{ inputs.rspec_cmd }}
+          "${{ inputs.rspec_cmd }}"
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,10 @@ on:
       tag:
         required: false
         type: string
+      rspec_cmd:
+        required: false
+        type: string
+        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
 env:
   REGISTRY: ghcr.io
 
@@ -91,10 +95,7 @@ jobs:
           # Use the index from matrix as an environment variable
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
         continue-on-error: true
-        run: >-
-          docker-compose exec -T web sh -c
-          "gem install semaphore_test_boosters &&
-          /usr/local/rvm/gems/default/wrappers/rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
+        run: docker-compose exec -T web sh -c ${{ rspec_cmd }}
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,7 @@ jobs:
           # Use the index from matrix as an environment variable
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
         continue-on-error: true
-        run: docker-compose exec -T web sh -c ${{ rspec_cmd }}
+        run: docker-compose exec -T web sh -c ${{ inputs.rspec_cmd }}
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails


### PR DESCRIPTION
**Use case:** When the default RSpec command doesn't work 

**Example:** Passenger-based Docker images use RVM. [LJK Brick](https://github.com/scientist-softserv/ljk-brick) uses one of these images. The default RSpec command does not work because gem executables are not set up correctly when doing `gem install <gem name>`. The default command gets overwritten with a one that does work here: https://github.com/scientist-softserv/ljk-brick/pull/71 

**See it in action:** https://github.com/scientist-softserv/ljk-brick/actions/runs/3439797570 