### PR TITLE
remove unused workflow_dispatch configs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,22 +1,5 @@
 name: "Build Docker Images"
 on:
-  workflow_dispatch:
-    inputs:
-      platforms:
-        default: "linux/amd64,linux/arm64"
-        type: string
-      tag:
-        required: false
-        type: string
-      target:
-        required: false
-        type: string
-      worker:
-        required: false
-        type: boolean
-      workerTarget:
-        required: false
-        type: string
   workflow_call:
     inputs:
       platforms:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,13 +1,5 @@
 name: "Lint for Rails Projects"
 on:
-  workflow_dispatch:
-    inputs:
-      worker:
-        required: false
-        type: boolean
-      tag:
-        required: false
-        type: string
   workflow_call:
     inputs:
       worker:

--- a/.github/workflows/retag.yaml
+++ b/.github/workflows/retag.yaml
@@ -1,13 +1,5 @@
 name: "Retag the item on main"
 on:
-  workflow_dispatch:
-    inputs:
-      worker:
-        required: false
-        type: boolean
-      tag:
-        required: false
-        type: string
   workflow_call:
     inputs:
       worker:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,17 +1,5 @@
 name: "Rspec for Rails Apps"
 on:
-  workflow_dispatch:
-    inputs:
-      worker:
-        required: false
-        type: boolean
-      tag:
-        required: false
-        type: string
-      rspec_cmd:
-        required: false
-        type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
   workflow_call:
     inputs:
       worker:


### PR DESCRIPTION
`workflow_dispatch` is used for manually triggering actions in GitHub's UI. Since we only call these actions from other repos (i.e. never run them inside this one), they aren't needed and may cause confusion if they're left