### PR TITLE
fix-build-issue-arm-vs-amd

### DIFF
--- a/.github/workflows/build-solr-arm64.yaml
+++ b/.github/workflows/build-solr-arm64.yaml
@@ -46,14 +46,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-      - name: Retag action for solr
-        id: meta-solr
-        uses: docker/metadata-action@v4.1.1
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr
-          tags: |
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -64,12 +56,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr:${{ env.TAG }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr:${{ env.TAG }}-arm
           context: .
           labels: ${{ steps.meta-solr.outputs.labels }}
           platforms: linux/arm64
           push: true
-          tags: |
-            ${{ steps.meta-solr.outputs.tags }}
-            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr:${{ env.TAG }}
+          tags: ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr:${{ env.TAG }}-arm
           target: ${{ inputs.target }}

--- a/.github/workflows/build-web-arm64.yaml
+++ b/.github/workflows/build-web-arm64.yaml
@@ -46,14 +46,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-      - name: Retag action for web
-        id: meta-web
-        uses: docker/metadata-action@v4.1.1
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}
-          tags: |
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -64,12 +56,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}:${{ env.TAG }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}:${{ env.TAG }}-arm
           context: .
           labels: ${{ steps.meta-web.outputs.labels }}
           platforms: linux/arm64
           push: true
-          tags: |
-            ${{ steps.meta-web.outputs.tags }}
-            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}:${{ env.TAG }}
+          tags: ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}:${{ env.TAG }}-arm
           target: ${{ inputs.target }}

--- a/.github/workflows/build-worker-arm64.yaml
+++ b/.github/workflows/build-worker-arm64.yaml
@@ -46,14 +46,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-      - name: Retag action for worker
-        id: meta-worker
-        uses: docker/metadata-action@v4.1.1
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker
-          tags: |
-            # set latest tag for default branch
-            type=raw,value=latest,enable={{is_default_branch}}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -64,12 +56,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker:${{ env.TAG }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker:${{ env.TAG }}-arm
           context: .
           labels: ${{ steps.meta-worker.outputs.labels }}
           platforms: linux/arm64
           push: true
-          tags: |
-            ${{ steps.meta-worker.outputs.tags }}
-            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker:${{ env.TAG }}
+          tags: ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker:${{ env.TAG }}-arm
           target: ${{ inputs.target }}


### PR DESCRIPTION
Additional content of issue: [Slack Thread](https://assaydepot.slack.com/archives/G0313NK4SMS/p1670572691196049?thread_ts=1670543697.971499&cid=G0313NK4SMS)

Deploys are failing because the arm64 images being pushed to the registry are overwritting the amd64 images needed for deployments.

My solution is to update the arm64 builds to:
1: Remove the retag action and its parts (not tag as latest when merged into default branch aka main).
2: Update the tag naming convention to something different so it can’t override the amd64 image we need for deployments.
