### PR TITLE
Version v0.0.14

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.12
+        uses: scientist-softserv/actions/setup-env@v0.0.14
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,13 +1,7 @@
 name: "Build Docker Images"
 on:
-  workflow_dispatch: {}
-
-  workflow_call:
+  workflow_dispatch:
     inputs:
-      base:
-        description: "Set true to build a base image, re-tag and push to the registry"
-        required: false
-        type: boolean
       baseTarget:
         description: "Used to set your target for the base image"
         required: false
@@ -16,16 +10,12 @@ on:
         description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
         type: string
       platforms:
-        description: "Which platforms you would like built through CI"
         default: "linux/amd64,linux/arm64"
+        description: "Which platforms you would like built through CI"
         type: string
       subdir:
         default: '.'
         type: string
-      solr:
-        description: "Set true to build a Solr image, re-tag and push to the registry"
-        required: false
-        type: boolean
       solrTarget:
         description: "Used to set your target for the solr image"
         required: false
@@ -37,18 +27,45 @@ on:
         description: "This is deprecated, dropping support after v0.0.11. It is now renamed to webTarget, you must also set web: true to trigger the build"
         required: false
         type: string
-      web:
-        description: "Set true to build a web image, re-tag and push to the registry"
-        required: false
-        type: boolean
       webTarget:
         description: "Used to set your target for the web image"
         required: false
         type: string
-      worker:
-        description: "Set true to build a worker image, re-tag and push to the registry"
+      workerTarget:
+        description: "Used to set your target for the worker image"
         required: false
-        type: boolean
+        type: string
+  workflow_call:
+    inputs:
+      baseTarget:
+        description: "Used to set your target for the base image"
+        required: false
+        type: string
+      image_name:
+        description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
+        type: string
+      platforms:
+        default: "linux/amd64,linux/arm64"
+        description: "Which platforms you would like built through CI"
+        type: string
+      subdir:
+        default: '.'
+        type: string
+      solrTarget:
+        description: "Used to set your target for the solr image"
+        required: false
+        type: string
+      tag:
+        required: false
+        type: string
+      target:
+        description: "This is deprecated, dropping support after v0.0.11. It is now renamed to webTarget, you must also set web: true to trigger the build"
+        required: false
+        type: string
+      webTarget:
+        description: "Used to set your target for the web image"
+        required: false
+        type: string
       workerTarget:
         description: "Used to set your target for the worker image"
         required: false
@@ -85,7 +102,8 @@ jobs:
           touch .env;
           TAG=latest docker-compose pull web || true
       - name: Retag action for base
-        if: ${{ inputs.base }}
+        if: ${{ inputs.baseTarget != '' }}
+        run: echo 'This step will only run if baseTarget has a value set.'
         id: meta-base
         uses: docker/metadata-action@v4.1.1
         with:
@@ -94,7 +112,8 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Retag action for web
-        if: ${{ inputs.web }}
+        if: ${{ inputs.webTarget != '' }}
+        run: echo 'This step will only run if webTarget has a value set.'
         id: meta-web
         uses: docker/metadata-action@v4.1.1
         with:
@@ -103,7 +122,8 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Retag action for worker
-        if: ${{ inputs.worker }}
+        if: ${{ inputs.workerTarget != '' }}
+        run: echo 'This step will only run if workerTarget has a value set.'
         id: meta-worker
         uses: docker/metadata-action@v4.1.1
         with:
@@ -112,7 +132,8 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Retag action for solr
-        if: ${{ inputs.solr }}
+        if: ${{ inputs.solrTarget != '' }}
+        run: echo 'This step will only run if baseTarget has a value set.'
         id: meta-solr
         uses: docker/metadata-action@v4.1.1
         with:
@@ -122,7 +143,8 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push base
         uses: docker/build-push-action@v3
-        if: ${{ inputs.base }}
+        if: ${{ inputs.baseTarget != '' }}
+        run: echo 'This step will only run if baseTarget has a value set.'
         with:
           build-args: |
             APP_PATH=${{ inputs.subdir }}
@@ -137,7 +159,8 @@ jobs:
           target: ${{ inputs.webTarget }}
       - name: Build and push web
         uses: docker/build-push-action@v3
-        if: ${{ inputs.web }}
+        if: ${{ inputs.webTarget != '' }}
+        run: echo 'This step will only run if webTarget has a value set.'
         with:
           build-args: |
             APP_PATH=${{ inputs.subdir }}
@@ -151,7 +174,8 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}:${{ env.TAG }}
           target: ${{ inputs.webTarget }}
       - name: Build and push worker
-        if: ${{ inputs.worker }}
+        if: ${{ inputs.workerTarget != '' }}
+        run: echo 'This step will only run if workerTarget has a value set.'
         uses: docker/build-push-action@v3
         with:
           build-args: |
@@ -166,7 +190,8 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker:${{ env.TAG }}
           target: ${{ inputs.workerTarget }}
       - name: Build and push solr
-        if: ${{ inputs.solr }}
+        if: ${{ inputs.solrTarget != '' }}
+        run: echo 'This step will only run if solrTarget has a value set.'
         uses: docker/build-push-action@v3
         with:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr:${{ env.TAG }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,62 +2,104 @@ name: "Build Docker Images"
 on:
   workflow_dispatch:
     inputs:
-      image_name:
+      base:
+        description: "Set true to build a base image and push to the registry"
+        required: false
+        type: boolean
+      baseTarget:
+        description: "Used to set your target for the base image"
+        required: false
         type: string
+      image_name:
         description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
+        type: string
       platforms:
         default: "linux/amd64,linux/arm64"
+        description: "Which platforms you would like built through CI"
         type: string
       subdir:
         default: '.'
         type: string
       solr:
-        description: "Use if you need to build a specific Solr image and push to the registry"
+        description: "Set true to build a specific Solr image and push to the registry"
         required: false
         type: boolean
       solrTarget:
+        description: "Used to set your target for the solr image"
         required: false
         type: string
       tag:
         required: false
         type: string
       target:
+        description: "This is deprecated, dropping support after v0.0.11. It is now renamed to webTarget, you must also set web: true to trigger the build"
+        required: false
+        type: string
+      web:
+        description: "Set true to build a web image and push to the registry"
+        required: false
+        type: boolean
+      webTarget:
+        description: "Used to set your target for the web image"
         required: false
         type: string
       worker:
+        description: "Set true to build a worker image and push to the registry"
         required: false
         type: boolean
       workerTarget:
+        description: "Used to set your target for the worker image"
         required: false
         type: string
   workflow_call:
     inputs:
-      image_name:
+      base:
+        description: "Set true to build a base image and push to the registry"
+        required: false
+        type: boolean
+      baseTarget:
+        description: "Used to set your target for the base image"
+        required: false
         type: string
+       image_name:
         description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
+        type: string
       platforms:
+        description: "Which platforms you would like built through CI"
         default: "linux/amd64,linux/arm64"
         type: string
       subdir:
         default: '.'
         type: string
       solr:
-        description: "Use if you need to build a specific Solr image and push to the registry"
+        description: "Set true to build a specific Solr image and push to the registry"
         required: false
         type: boolean
       solrTarget:
+        description: "Used to set your target for the solr image"
         required: false
         type: string
       tag:
         required: false
         type: string
       target:
+        description: "This is deprecated, dropping support after v0.0.11. It is now renamed to webTarget, you must also set web: true to trigger the build"
+        required: false
+        type: string
+      web:
+        description: "Set true to build a web image and push to the registry"
+        required: false
+        type: boolean
+      webTarget:
+        description: "Used to set your target for the web image"
         required: false
         type: string
       worker:
+        description: "Set true to build a worker image and push to the registry"
         required: false
         type: boolean
       workerTarget:
+        description: "Used to set your target for the worker image"
         required: false
         type: string
 
@@ -70,7 +112,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.11
+        uses: scientist-softserv/actions/setup-env@v0.0.12
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}
@@ -91,7 +133,17 @@ jobs:
           touch .env.development;
           touch .env;
           TAG=latest docker-compose pull web || true
+      - name: Retag action for base
+        if: ${{ inputs.base }}
+        id: meta-base
+        uses: docker/metadata-action@v4.1.1
+        with:
+          images: |
+            name=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/base
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
       - name: Retag action for web
+        if: ${{ inputs.web }}
         id: meta-web
         uses: docker/metadata-action@v4.1.1
         with:
@@ -117,8 +169,24 @@ jobs:
             name=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+      - name: Build and push base
+        uses: docker/build-push-action@v3
+        if: ${{ inputs.base }}
+        with:
+          build-args: |
+            APP_PATH=${{ inputs.subdir }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/base:${{ env.TAG }}
+          context: .
+          file: ${{ inputs.subdir}}/Dockerfile
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: |
+            ${{ steps.meta-base.outputs.tags }}
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/base:${{ env.TAG }}
+          target: ${{ inputs.webTarget }}
       - name: Build and push web
         uses: docker/build-push-action@v3
+        if: ${{ inputs.web }}
         with:
           build-args: |
             APP_PATH=${{ inputs.subdir }}
@@ -130,7 +198,7 @@ jobs:
           tags: |
             ${{ steps.meta-web.outputs.tags }}
             ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}:${{ env.TAG }}
-          target: ${{ inputs.target }}
+          target: ${{ inputs.webTarget }}
       - name: Build and push worker
         if: ${{ inputs.worker }}
         uses: docker/build-push-action@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,12 +13,12 @@ on:
         default: "linux/amd64,linux/arm64"
         description: "Which platforms you would like built through CI"
         type: string
-      subdir:
-        default: '.'
-        type: string
       solrTarget:
         description: "Used to set your target for the solr image"
         required: false
+        type: string
+      subdir:
+        default: '.'
         type: string
       tag:
         required: false
@@ -44,12 +44,12 @@ on:
         default: "linux/amd64,linux/arm64"
         description: "Which platforms you would like built through CI"
         type: string
-      subdir:
-        default: '.'
-        type: string
       solrTarget:
         description: "Used to set your target for the solr image"
         required: false
+        type: string
+      subdir:
+        default: '.'
         type: string
       tag:
         required: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.14
+        uses: scientist-softserv/actions/setup-env@adl-update-build
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ on:
         description: "Used to set your target for the base image"
         required: false
         type: string
-       image_name:
+      image_name:
         description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
         type: string
       platforms:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -136,7 +136,7 @@ jobs:
         with:
           build-args: |
             APP_PATH=${{ inputs.subdir }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/base:${{ env.TAG }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/base:latest
           context: .
           file: ${{ inputs.subdir}}/Dockerfile
           platforms: ${{ inputs.platforms }}
@@ -151,7 +151,7 @@ jobs:
         with:
           build-args: |
             APP_PATH=${{ inputs.subdir }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}:${{ env.TAG }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}:latest
           context: .
           file: ${{ inputs.subdir}}/Dockerfile
           platforms: ${{ inputs.platforms }}
@@ -166,7 +166,7 @@ jobs:
         with:
           build-args: |
             APP_PATH=${{ inputs.subdir }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker:${{ env.TAG }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/worker:latest
           context: .
           file: ${{ inputs.subdir}}/Dockerfile
           platforms: ${{ inputs.platforms }}
@@ -179,7 +179,7 @@ jobs:
         if: ${{ inputs.solrTarget != '' }}
         uses: docker/build-push-action@v3
         with:
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr:${{ env.TAG }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr:latest
           context: ./solr
           platforms: ${{ inputs.platforms }}
           push: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,60 +1,11 @@
 name: "Build Docker Images"
 on:
-  workflow_dispatch:
-    inputs:
-      base:
-        description: "Set true to build a base image and push to the registry"
-        required: false
-        type: boolean
-      baseTarget:
-        description: "Used to set your target for the base image"
-        required: false
-        type: string
-      image_name:
-        description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
-        type: string
-      platforms:
-        default: "linux/amd64,linux/arm64"
-        description: "Which platforms you would like built through CI"
-        type: string
-      subdir:
-        default: '.'
-        type: string
-      solr:
-        description: "Set true to build a specific Solr image and push to the registry"
-        required: false
-        type: boolean
-      solrTarget:
-        description: "Used to set your target for the solr image"
-        required: false
-        type: string
-      tag:
-        required: false
-        type: string
-      target:
-        description: "This is deprecated, dropping support after v0.0.11. It is now renamed to webTarget, you must also set web: true to trigger the build"
-        required: false
-        type: string
-      web:
-        description: "Set true to build a web image and push to the registry"
-        required: false
-        type: boolean
-      webTarget:
-        description: "Used to set your target for the web image"
-        required: false
-        type: string
-      worker:
-        description: "Set true to build a worker image and push to the registry"
-        required: false
-        type: boolean
-      workerTarget:
-        description: "Used to set your target for the worker image"
-        required: false
-        type: string
+  workflow_dispatch: {}
+
   workflow_call:
     inputs:
       base:
-        description: "Set true to build a base image and push to the registry"
+        description: "Set true to build a base image, re-tag and push to the registry"
         required: false
         type: boolean
       baseTarget:
@@ -72,7 +23,7 @@ on:
         default: '.'
         type: string
       solr:
-        description: "Set true to build a specific Solr image and push to the registry"
+        description: "Set true to build a Solr image, re-tag and push to the registry"
         required: false
         type: boolean
       solrTarget:
@@ -87,7 +38,7 @@ on:
         required: false
         type: string
       web:
-        description: "Set true to build a web image and push to the registry"
+        description: "Set true to build a web image, re-tag and push to the registry"
         required: false
         type: boolean
       webTarget:
@@ -95,7 +46,7 @@ on:
         required: false
         type: string
       worker:
-        description: "Set true to build a worker image and push to the registry"
+        description: "Set true to build a worker image, re-tag and push to the registry"
         required: false
         type: boolean
       workerTarget:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,10 +23,6 @@ on:
       tag:
         required: false
         type: string
-      target:
-        description: "This is deprecated, dropping support after v0.0.11. It is now renamed to webTarget, you must also set web: true to trigger the build"
-        required: false
-        type: string
       webTarget:
         description: "Used to set your target for the web image"
         required: false
@@ -56,10 +52,6 @@ on:
         required: false
         type: string
       tag:
-        required: false
-        type: string
-      target:
-        description: "This is deprecated, dropping support after v0.0.11. It is now renamed to webTarget, you must also set web: true to trigger the build"
         required: false
         type: string
       webTarget:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,6 @@ jobs:
           TAG=latest docker-compose pull web || true
       - name: Retag action for base
         if: ${{ inputs.baseTarget != '' }}
-        run: echo 'This step will only run if baseTarget has a value set.'
         id: meta-base
         uses: docker/metadata-action@v4.1.1
         with:
@@ -113,7 +112,6 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Retag action for web
         if: ${{ inputs.webTarget != '' }}
-        run: echo 'This step will only run if webTarget has a value set.'
         id: meta-web
         uses: docker/metadata-action@v4.1.1
         with:
@@ -123,7 +121,6 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Retag action for worker
         if: ${{ inputs.workerTarget != '' }}
-        run: echo 'This step will only run if workerTarget has a value set.'
         id: meta-worker
         uses: docker/metadata-action@v4.1.1
         with:
@@ -133,7 +130,6 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Retag action for solr
         if: ${{ inputs.solrTarget != '' }}
-        run: echo 'This step will only run if baseTarget has a value set.'
         id: meta-solr
         uses: docker/metadata-action@v4.1.1
         with:
@@ -144,7 +140,6 @@ jobs:
       - name: Build and push base
         uses: docker/build-push-action@v3
         if: ${{ inputs.baseTarget != '' }}
-        run: echo 'This step will only run if baseTarget has a value set.'
         with:
           build-args: |
             APP_PATH=${{ inputs.subdir }}
@@ -160,7 +155,6 @@ jobs:
       - name: Build and push web
         uses: docker/build-push-action@v3
         if: ${{ inputs.webTarget != '' }}
-        run: echo 'This step will only run if webTarget has a value set.'
         with:
           build-args: |
             APP_PATH=${{ inputs.subdir }}
@@ -175,7 +169,6 @@ jobs:
           target: ${{ inputs.webTarget }}
       - name: Build and push worker
         if: ${{ inputs.workerTarget != '' }}
-        run: echo 'This step will only run if workerTarget has a value set.'
         uses: docker/build-push-action@v3
         with:
           build-args: |
@@ -191,7 +184,6 @@ jobs:
           target: ${{ inputs.workerTarget }}
       - name: Build and push solr
         if: ${{ inputs.solrTarget != '' }}
-        run: echo 'This step will only run if solrTarget has a value set.'
         uses: docker/build-push-action@v3
         with:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/solr:${{ env.TAG }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Pull from cache to speed up build
+      - name: Pull from cache to speed up web build
+        if: ${{ inputs.webTarget != '' }}
         run: >-
           cd ${{ inputs.subdir }};
           touch .env.development;
@@ -130,8 +131,8 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push base
-        uses: docker/build-push-action@v3
         if: ${{ inputs.baseTarget != '' }}
+        uses: docker/build-push-action@v3
         with:
           build-args: |
             APP_PATH=${{ inputs.subdir }}
@@ -145,8 +146,8 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/base:${{ env.TAG }}
           target: ${{ inputs.webTarget }}
       - name: Build and push web
-        uses: docker/build-push-action@v3
         if: ${{ inputs.webTarget != '' }}
+        uses: docker/build-push-action@v3
         with:
           build-args: |
             APP_PATH=${{ inputs.subdir }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@adl-update-build
+        uses: scientist-softserv/actions/setup-env@v0.0.14
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.14
+        uses: scientist-softserv/actions/setup-env@adl-update-build
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,8 +11,8 @@ on:
       k8s-namespace:
         required: false
         type: string
-      solr:
-        description: "Add if your solr image is from the registry"
+      solrTarget:
+        description: "Used if you have a solr image to deploy"
         required: false
         type: boolean
       tag:
@@ -78,7 +78,7 @@ jobs:
         with:
           limit-access-to-actor: true
       - name: Do deploy with solr registry image
-        if: ${{ inputs.solr }}
+        if: ${{ inputs.solrTarget }}
         run: |
           echo $KUBECONFIG_FILE | base64 -d > $KUBECONFIG;
           DOLLAR=$ envsubst < ops/${{ inputs.environment }}-deploy.tmpl.yaml > ops/${{ inputs.environment }}-deploy.yaml;

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@adl-update-build
+        uses: scientist-softserv/actions/setup-env@v0.0.14
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.11
+        uses: scientist-softserv/actions/setup-env@v0.0.14
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ on:
       k8s-namespace:
         required: false
         type: string
-      solrTarget:
+      deploy-solr-image:
         description: "Used if you have a solr image to deploy"
         required: false
         type: boolean
@@ -77,8 +77,8 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
         with:
           limit-access-to-actor: true
-      - name: Do deploy with solr registry image
-        if: ${{ inputs.solrTarget }}
+      - name: Do deploy with solr image
+        if: ${{ inputs.deploy-solr-image }}
         run: |
           echo $KUBECONFIG_FILE | base64 -d > $KUBECONFIG;
           DOLLAR=$ envsubst < ops/${{ inputs.environment }}-deploy.tmpl.yaml > ops/${{ inputs.environment }}-deploy.yaml;
@@ -88,6 +88,7 @@ jobs:
           export SOLR_IMAGE=ghcr.io/${REPO_LOWER}/solr;
           ./bin/helm_deploy ${{ inputs.k8s-release-name || format('{0}-{1}', github.event.repository.name, inputs.environment) }} ${{ inputs.k8s-namespace || format('{0}-{1}', github.event.repository.name, inputs.environment) }}
       - name: Do deploy
+        if: ${{ inputs.deploy-solr-image }} == 'false'
         run: |
           echo $KUBECONFIG_FILE | base64 -d > $KUBECONFIG;
           DOLLAR=$ envsubst < ops/${{ inputs.environment }}-deploy.tmpl.yaml > ops/${{ inputs.environment }}-deploy.yaml;

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,23 +2,41 @@ name: "Lint for Rails Projects"
 on:
   workflow_dispatch:
     inputs:
+      base:
+        required: false
+        type: boolean
       subdir:
         default: '.'
         type: string
+      solr:
+        required: false
+        type: boolean
       tag:
         required: false
         type: string
+      web:
+        required: false
+        type: boolean
       worker:
         required: false
         type: boolean
   workflow_call:
     inputs:
+      base:
+        required: false
+        type: boolean
       subdir:
         default: '.'
         type: string
+      solr:
+        required: false
+        type: boolean
       tag:
         required: false
         type: string
+      web:
+        required: false
+        type: boolean
       worker:
         required: false
         type: boolean
@@ -42,17 +60,28 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Pull image to prevent build
+      - name: Pull base image to prevent build
+        if: ${{ inputs.base }}
+        run: >-
+          cd ${{ inputs.subdir }};
+          docker-compose pull base
+      - name: Pull solr image to prevent build
+        if: ${{ inputs.solr }}
+        run: >-
+          cd ${{ inputs.subdir }};
+          docker-compose pull solr
+      - name: Pull web image to prevent build
+        if: ${{ inputs.web }}
         run: >-
           cd ${{ inputs.subdir }};
           touch .env.development;
           touch .env;
           docker-compose pull web
       - name: Pull worker image to prevent build
+        if: ${{ inputs.worker }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull worker
-        if: ${{ inputs.worker }}
       - name: Run Rubocop
         run: >-
           cd ${{ inputs.subdir }};

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,13 +3,13 @@ on:
   workflow_dispatch:
     inputs:
       baseTarget:
-        description: "Used to enable the linter to run on the base image"
+        description: "Used to set your target for the base image"
         required: false
-        type: boolean
+        type: string
       solrTarget:
-        description: "Used to enable the linter to run on the solr image"
+        description: "Used to set your target for the solr image"
         required: false
-        type: boolean
+        type: string
       subdir:
         default: '.'
         type: string
@@ -17,23 +17,23 @@ on:
         required: false
         type: string
       webTarget:
-        description: "Used to enable the linter to run on the web image"
+        description: "Used to set your target for the web image"
         required: false
-        type: boolean
+        type: string
       workerTarget:
-        description: "Used to enable the linter to run on the worker image"
+        description: "Used to set your target for the worker image"
         required: false
-        type: boolean
+        type: string
   workflow_call:
     inputs:
       baseTarget:
-        description: "Used to enable the linter to run on the base image"
+        description: "Used to set your target for the base image"
         required: false
-        type: boolean
+        type: string
       solrTarget:
-        description: "Used to enable the linter to run on the solr image"
+        description: "Used to set your target for the solr image"
         required: false
-        type: boolean
+        type: string
       subdir:
         default: '.'
         type: string
@@ -41,13 +41,13 @@ on:
         required: false
         type: string
       webTarget:
-        description: "Used to enable the linter to run on the web image"
+        description: "Used to set your target for the web image"
         required: false
-        type: boolean
+        type: string
       workerTarget:
-        description: "Used to enable the linter to run on the worker image"
+        description: "Used to set your target for the worker image"
         required: false
-        type: boolean
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -69,24 +69,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull base image to prevent build
-        if: ${{ inputs.baseTarget }}
+        if: ${{ inputs.baseTarget != '' }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull base
       - name: Pull solr image to prevent build
-        if: ${{ inputs.solrTarget }}
+        if: ${{ inputs.solrTarget != '' }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull solr
       - name: Pull web image to prevent build
-        if: ${{ inputs.webTarget }}
+        if: ${{ inputs.webTarget != '' }}
         run: >-
           cd ${{ inputs.subdir }};
           touch .env.development;
           touch .env;
           docker-compose pull web
       - name: Pull worker image to prevent build
-        if: ${{ inputs.workerTarget }}
+        if: ${{ inputs.workerTarget != '' }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull worker

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.11
+        uses: scientist-softserv/actions/setup-env@v0.0.14
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.14
+        uses: scientist-softserv/actions/setup-env@adl-update-build
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,42 +2,50 @@ name: "Lint for Rails Projects"
 on:
   workflow_dispatch:
     inputs:
-      base:
+      baseTarget:
+        description: "Used to enable the linter to run on the base image"
+        required: false
+        type: boolean
+      solrTarget:
+        description: "Used to enable the linter to run on the solr image"
         required: false
         type: boolean
       subdir:
         default: '.'
         type: string
-      solr:
-        required: false
-        type: boolean
       tag:
         required: false
         type: string
-      web:
+      webTarget:
+        description: "Used to enable the linter to run on the web image"
         required: false
         type: boolean
-      worker:
+      workerTarget:
+        description: "Used to enable the linter to run on the worker image"
         required: false
         type: boolean
   workflow_call:
     inputs:
-      base:
+      baseTarget:
+        description: "Used to enable the linter to run on the base image"
+        required: false
+        type: boolean
+      solrTarget:
+        description: "Used to enable the linter to run on the solr image"
         required: false
         type: boolean
       subdir:
         default: '.'
         type: string
-      solr:
-        required: false
-        type: boolean
       tag:
         required: false
         type: string
-      web:
+      webTarget:
+        description: "Used to enable the linter to run on the web image"
         required: false
         type: boolean
-      worker:
+      workerTarget:
+        description: "Used to enable the linter to run on the worker image"
         required: false
         type: boolean
 
@@ -61,24 +69,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull base image to prevent build
-        if: ${{ inputs.base }}
+        if: ${{ inputs.baseTarget }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull base
       - name: Pull solr image to prevent build
-        if: ${{ inputs.solr }}
+        if: ${{ inputs.solrTarget }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull solr
       - name: Pull web image to prevent build
-        if: ${{ inputs.web }}
+        if: ${{ inputs.webTarget }}
         run: >-
           cd ${{ inputs.subdir }};
           touch .env.development;
           touch .env;
           docker-compose pull web
       - name: Pull worker image to prevent build
-        if: ${{ inputs.worker }}
+        if: ${{ inputs.workerTarget }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull worker

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@adl-update-build
+        uses: scientist-softserv/actions/setup-env@v0.0.14
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,19 +2,14 @@ name: "Rspec for Rails Apps"
 on:
   workflow_dispatch:
     inputs:
-      base:
+      baseTarget:
+        description: "Used to enable tests to run on the base image"
         required: false
         type: boolean
       confdir:
         required: false
         type: string
         default: "/app/samvera/hyrax-webapp/solr/config"
-      subdir:
-        default: '.'
-        type: string
-      tag:
-        required: false
-        type: string
       rspec_cmd:
         required: false
         type: string
@@ -23,30 +18,34 @@ on:
         required: false
         type: string
         default: "RAILS_ENV=test bundle exec rake db:create db:schema:load db:migrate"
-      solr:
+      solrTarget:
+        description: "Used to enable tests to run on the solr image"
         required: false
         type: boolean
-      web:
+      subdir:
+        default: '.'
+        type: string
+      tag:
+        required: false
+        type: string
+      webTarget:
+        description: "Used to enable tests to run on the web image"
         required: false
         type: boolean
-      worker:
+      workerTarget:
+        description: "Used to enable tests to run on the worker image"
         required: false
         type: boolean
   workflow_call:
     inputs:
-      base:
+      baseTarget:
+        description: "Used to enable tests to run on the base image"
         required: false
         type: boolean
       confdir:
         required: false
         type: string
         default: "/app/samvera/hyrax-webapp/solr/config"
-      subdir:
-        default: '.'
-        type: string
-      tag:
-        required: false
-        type: string
       rspec_cmd:
         required: false
         type: string
@@ -55,13 +54,22 @@ on:
         required: false
         type: string
         default: "RAILS_ENV=test bundle exec rake db:create db:schema:load db:migrate"
-      solr:
+      solrTarget:
+        description: "Used to enable tests to run on the solr image"
         required: false
         type: boolean
-      web:
+      subdir:
+        default: '.'
+        type: string
+      tag:
+        required: false
+        type: string
+      webTarget:
+        description: "Used to enable tests to run on the web image"
         required: false
         type: boolean
-      worker:
+      workerTarget:
+        description: "Used to enable tests to run on the worker image"
         required: false
         type: boolean
 
@@ -106,24 +114,24 @@ jobs:
         with:
           limit-access-to-actor: true
       - name: Pull base image to prevent build
-        if: ${{ inputs.base }}
+        if: ${{ inputs.baseTarget }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull base
       - name: Pull solr image to prevent build
-        if: ${{ inputs.solr }}
+        if: ${{ inputs.solrTarget }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull solr
       - name: Pull web image to prevent build
-        if: ${{ inputs.web }}
+        if: ${{ inputs.webTarget }}
         run: >-
           cd ${{ inputs.subdir }};
           touch .env.development;
           touch .env;
           docker-compose pull web
       - name: Pull worker image to prevent build
-        if: ${{ inputs.worker }}
+        if: ${{ inputs.workerTarget }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull worker
@@ -133,7 +141,7 @@ jobs:
           [ -f "db/schema.rb" ] && chmod 777 db/schema.rb;
           docker-compose up -d web
       - name: Setup Solr
-        if: ${{ inputs.solr }}
+        if: ${{ inputs.solrTarget }}
         shell: bash
         run: >-
           cd ${{ inputs.subdir }};

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: "Rspec for Rails Apps"
 on:
   workflow_dispatch:
     inputs:
+      base:
+        required: false
+        type: boolean
       confdir:
         required: false
         type: string
@@ -20,11 +23,20 @@ on:
         required: false
         type: string
         default: "RAILS_ENV=test bundle exec rake db:create db:schema:load db:migrate"
+      solr:
+        required: false
+        type: boolean
+      web:
+        required: false
+        type: boolean
       worker:
         required: false
         type: boolean
   workflow_call:
     inputs:
+      base:
+        required: false
+        type: boolean
       confdir:
         required: false
         type: string
@@ -43,6 +55,12 @@ on:
         required: false
         type: string
         default: "RAILS_ENV=test bundle exec rake db:create db:schema:load db:migrate"
+      solr:
+        required: false
+        type: boolean
+      web:
+        required: false
+        type: boolean
       worker:
         required: false
         type: boolean
@@ -87,7 +105,18 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
         with:
           limit-access-to-actor: true
-      - name: Pull image to prevent build
+      - name: Pull base image to prevent build
+        if: ${{ inputs.base }}
+        run: >-
+          cd ${{ inputs.subdir }};
+          docker-compose pull base
+      - name: Pull solr image to prevent build
+        if: ${{ inputs.solr }}
+        run: >-
+          cd ${{ inputs.subdir }};
+          docker-compose pull solr
+      - name: Pull web image to prevent build
+        if: ${{ inputs.web }}
         run: >-
           cd ${{ inputs.subdir }};
           touch .env.development;
@@ -103,19 +132,15 @@ jobs:
           cd ${{ inputs.subdir }};
           [ -f "db/schema.rb" ] && chmod 777 db/schema.rb;
           docker-compose up -d web
-      - name: Check for and setup Solr if needed
+      - name: Setup Solr
+        if: ${{ inputs.solr }}
         shell: bash
-        run: |
+        run: >-
           cd ${{ inputs.subdir }};
-          if [ -d solr ]
-          then
-            docker-compose exec -T web sh -c \
-            "solrcloud-upload-configset.sh "${CONFDIR}" &&
-            SOLR_COLLECTION_NAME=hydra-test solrcloud-assign-configset.sh &&
-            solrcloud-assign-configset.sh"
-          else
-            echo "No solr directory found, skipping..."
-          fi
+          docker-compose exec -T web sh -c;
+          solrcloud-upload-configset.sh "${CONFDIR}";
+          SOLR_COLLECTION_NAME=hydra-test solrcloud-assign-configset.sh;
+          solrcloud-assign-configset.sh
       - name: Setup db
         run: >-
           cd ${{ inputs.subdir }};

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.14
+        uses: scientist-softserv/actions/setup-env@adl-update-build
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.11
+        uses: scientist-softserv/actions/setup-env@v0.0.14
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       baseTarget:
-        description: "Used to enable tests to run on the base image"
+        description: "Used to set your target for the base image"
         required: false
-        type: boolean
+        type: string
       confdir:
         required: false
         type: string
@@ -19,9 +19,9 @@ on:
         type: string
         default: "RAILS_ENV=test bundle exec rake db:create db:schema:load db:migrate"
       solrTarget:
-        description: "Used to enable tests to run on the solr image"
+        description: "Used to set your target for the solr image"
         required: false
-        type: boolean
+        type: string
       subdir:
         default: '.'
         type: string
@@ -29,19 +29,19 @@ on:
         required: false
         type: string
       webTarget:
-        description: "Used to enable tests to run on the web image"
+        description: "Used to set your target for the web image"
         required: false
-        type: boolean
+        type: string
       workerTarget:
-        description: "Used to enable tests to run on the worker image"
+        description: "Used to set your target for the worker image"
         required: false
-        type: boolean
+        type: string
   workflow_call:
     inputs:
       baseTarget:
-        description: "Used to enable tests to run on the base image"
+        description: "Used to set your target for the base image"
         required: false
-        type: boolean
+        type: string
       confdir:
         required: false
         type: string
@@ -55,9 +55,9 @@ on:
         type: string
         default: "RAILS_ENV=test bundle exec rake db:create db:schema:load db:migrate"
       solrTarget:
-        description: "Used to enable tests to run on the solr image"
+        description: "Used to set your target for the solr image"
         required: false
-        type: boolean
+        type: string
       subdir:
         default: '.'
         type: string
@@ -65,13 +65,13 @@ on:
         required: false
         type: string
       webTarget:
-        description: "Used to enable tests to run on the web image"
+        description: "Used to set your target for the web image"
         required: false
-        type: boolean
+        type: string
       workerTarget:
-        description: "Used to enable tests to run on the worker image"
+        description: "Used to set your target for the worker image"
         required: false
-        type: boolean
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -114,24 +114,24 @@ jobs:
         with:
           limit-access-to-actor: true
       - name: Pull base image to prevent build
-        if: ${{ inputs.baseTarget }}
+        if: ${{ inputs.baseTarget != '' }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull base
       - name: Pull solr image to prevent build
-        if: ${{ inputs.solrTarget }}
+        if: ${{ inputs.solrTarget != '' }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull solr
       - name: Pull web image to prevent build
-        if: ${{ inputs.webTarget }}
+        if: ${{ inputs.webTarget != '' }}
         run: >-
           cd ${{ inputs.subdir }};
           touch .env.development;
           touch .env;
           docker-compose pull web
       - name: Pull worker image to prevent build
-        if: ${{ inputs.workerTarget }}
+        if: ${{ inputs.workerTarget != '' }}
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose pull worker
@@ -141,7 +141,7 @@ jobs:
           [ -f "db/schema.rb" ] && chmod 777 db/schema.rb;
           docker-compose up -d web
       - name: Setup Solr
-        if: ${{ inputs.solrTarget }}
+        if: ${{ inputs.solrTarget != '' }}
         shell: bash
         run: >-
           cd ${{ inputs.subdir }};

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@adl-update-build
+        uses: scientist-softserv/actions/setup-env@v0.0.14
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -1,10 +1,10 @@
 name: "Set up env vars"
 description: "Set up env vars"
 inputs:
-  tag:
+  image_name:
     required: false
     type: string
-  image_name:
+  tag:
     required: false
     type: string
   token:


### PR DESCRIPTION
New workflow_dispatch inputs:
- baseTarget
- webTarget

Base, web, worker & solr:
- if clause added to each retag action with proper registry tagging
- if clause added to each build and push action

Removed some workflow_dispatch inputs since the max workflow_dispatch inputs we can have (for now) are 10. I had to get creative in replacing the if clauses from the boolean options to if the baseTarget, solrTarget, webTarget, and/or workerTarget are not empty (ex: `if: ${{ inputs.webTarget != '' }}`), so that it would trigger a workflow block to run with just the target set. Removing the need for the workflow_dispatch inputs:
```yaml
worker:
  required: false
  type: boolean
```
As well as setting base, solr, web, and/or worker to true (ex: `worker: true`) in the associated reusable workflow. 