### PR TITLE
the pipeline should fail when a spec does

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -129,11 +129,13 @@ jobs:
           CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           # Use the index from matrix as an environment variable
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
-        continue-on-error: false
+        continue-on-error: true
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose exec -T web sh -c
           "${{ inputs.rspec_cmd }}"
+      - name: Invert success and failure
+        run: if [[ ${{ steps.run-specs.outcome }} == "failure" ]]; then exit 0; else exit 1; fi
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -135,7 +135,7 @@ jobs:
           docker-compose exec -T web sh -c
           "${{ inputs.rspec_cmd }}"
       - name: Invert success and failure
-        run: if [[ ${{ steps.run-specs.outcome }} == "failure" ]]; then exit 0; else exit 1; fi
+        run: if [[ ${{ steps.run-specs.outcome }} == "failure" ]]; then exit 1; else exit 0; fi
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -122,6 +122,7 @@ jobs:
           docker-compose exec -T web sh -c
           "${{ inputs.setup_db_cmd }}"
       - name: Run Specs
+        id: run-specs
         env:
           # Specifies how many jobs you would like to run in parallel,
           # used for partitioning
@@ -133,6 +134,8 @@ jobs:
           cd ${{ inputs.subdir }};
           docker-compose exec -T web sh -c
           "${{ inputs.rspec_cmd }}"
+      - name: Invert success and failure
+        run: if [[ ${{ steps.run-specs.outcome }} == "failure" ]]; then exit 0; else exit 1; fi
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -134,7 +134,7 @@ jobs:
           cd ${{ inputs.subdir }};
           docker-compose exec -T web sh -c
           "${{ inputs.rspec_cmd }}"
-      - name: Invert success and failure
+      - name: Fail job if spec failure
         run: if [[ ${{ steps.run-specs.outcome }} == "failure" ]]; then exit 1; else exit 0; fi
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -129,13 +129,11 @@ jobs:
           CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           # Use the index from matrix as an environment variable
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
-        continue-on-error: true
+        continue-on-error: false
         run: >-
           cd ${{ inputs.subdir }};
           docker-compose exec -T web sh -c
           "${{ inputs.rspec_cmd }}"
-      - name: Invert success and failure
-        run: if [[ ${{ steps.run-specs.outcome }} == "failure" ]]; then exit 0; else exit 1; fi
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails


### PR DESCRIPTION
# Summary 
- [ ] A repo's pipeline to fail when a spec fails.

## Resources: 

```
jobs.<job_id>.steps[*].continue-on-error

Prevents a job from failing when a step fails. Set to true to allow a job to pass when this step fails.

```

<img width="711" alt="image" src="https://user-images.githubusercontent.com/10081604/223775572-3189b79e-bf1a-4900-991c-b0a76c2df9d0.png">


https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error

https://docs.github.com/en/actions/learn-github-actions/contexts

https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions

https://stackoverflow.com/questions/60589373/how-to-force-to-exit-in-github-actions-step



https://stackoverflow.com/questions/71433926/how-do-to-run-the-next-github-action-step-even-if-the-previous-step-failed-whil


## SCREENSHOTS (I intentionally made sure specs were failing for iiif_print, which is the repo I used to test this)

ref: https://github.com/scientist-softserv/iiif_print/actions/runs/4366971041/jobs/7637783866

<img width="1499" alt="Screenshot 2023-03-08 at 10 02 42 AM" src="https://user-images.githubusercontent.com/10081604/223793835-3a4e8bdb-7843-49da-989a-ae5cbae858f1.png">

<img width="910" alt="image" src="https://user-images.githubusercontent.com/10081604/223794271-a2d2cfab-ca8b-4fed-819d-7cef94fd3725.png">


<img width="1470" alt="image" src="https://user-images.githubusercontent.com/10081604/223794010-a058daf6-4e2b-45a2-bc05-77a11b1d2389.png">
 🎉 