### PR TITLE
add-prune-ghcr-images-after-merge-to-main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.11
+        uses: scientist-softserv/actions/setup-env@add-prune-ghcr-images-after-merge-to-main
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -1,6 +1,6 @@
 name: Cleanup PR Registry Images
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       image_name:
         description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -29,7 +29,6 @@ env:
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
 jobs:
   delete-image:
-    if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
       - id: setup

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -1,0 +1,69 @@
+name: Cleanup PR Registry Images
+on:
+  pull_request:
+    types:
+      - closed
+  inputs:
+    webImage:
+      description: "Delete the web container registry image"
+      required: true
+      type: boolean
+    workerImage:
+      description: "Delete the worker container registry image"
+      required: true
+      type: boolean
+
+permissions:
+  contents: read
+  packages: write
+  security-events: write
+
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+jobs:
+  if-merged-delete-image:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - id: setup
+        name: Setup
+        uses: scientist-softserv/actions/setup-env@add-prune-ghcr-images-after-merge-to-main
+        with:
+          tag: ${{ inputs.tag }}
+          image_name: ${{ inputs.image_name }}
+          token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Delete web image
+        if: ${{ inputs.webImage }}
+        uses: bots-house/ghcr-delete-image-action@v1.1.0
+        with:
+          # NOTE: at now only orgs is supported
+          owner: scientist-softserv
+          name: ${{ env.REPO_LOWER }}
+          # NOTE: using Personal Access Token
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#granting-additional-permissions
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # token: ${{ secrets.PAT }}
+          tag: ${{ inputs.tag }}
+      - name: Delete worker image
+        if: ${{ inputs.workerImage }}
+        uses: bots-house/ghcr-delete-image-action@v1.1.0
+        with:
+          # NOTE: at now only orgs is supported
+          owner: scientist-softserv
+          name: ${{ env.REPO_LOWER }}/worker
+          # NOTE: using Personal Access Token
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#granting-additional-permissions
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # token: ${{ secrets.PAT }}
+          tag: ${{ inputs.tag }}

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -31,10 +31,6 @@ jobs:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -25,7 +25,7 @@ permissions:
 
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
 jobs:
-  if-merged-delete-image:
+  delete-image:
     runs-on: ubuntu-latest
     steps:
       - id: setup
@@ -42,7 +42,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Delete web image
-        if: ${{ inputs.webImage && github.event.action == 'closed' && github.event.pull_request.merged = true }}
+        if: ${{ inputs.webImage }}
         uses: bots-house/ghcr-delete-image-action@v1.1.0
         with:
           # NOTE: at now only orgs is supported
@@ -53,9 +53,9 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
           token: ${{ secrets.GITHUB_TOKEN }}
           # token: ${{ secrets.PAT }}
-          tag: ${{ env.$TAG }}
+          tag: ${{ env.TAG }}
       - name: Delete worker image
-        if: ${{ inputs.workerImage && github.event.action == 'closed' && github.event.pull_request.merged = true }}
+        if: ${{ inputs.workerImage }}
         uses: bots-house/ghcr-delete-image-action@v1.1.0
         with:
           # NOTE: at now only orgs is supported
@@ -66,4 +66,4 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
           token: ${{ secrets.GITHUB_TOKEN }}
           # token: ${{ secrets.PAT }}
-          tag: ${{ inputs.tag }}
+          tag: ${{ env.TAG }}

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -4,6 +4,13 @@ on:
     types:
       - closed
   inputs:
+    image_name:
+      description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
+      required: true
+      type: string
+    tag:
+      required: true
+      type: string
     webImage:
       description: "Delete the web container registry image"
       required: true

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -1,6 +1,6 @@
 name: Cleanup PR Registry Images
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       image_name:
         description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -1,7 +1,6 @@
 name: Cleanup PR Registry Images
 on:
-  pull_request:
-    types: [opened, closed]
+  workflow_call:
     inputs:
       image_name:
         description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -1,22 +1,23 @@
 name: Cleanup PR Registry Images
 on:
-  workflow_call:
-    inputs:
-      image_name:
-        description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
-        required: false
-        type: string
-      tag:
-        required: false
-        type: string
-      webImage:
-        description: "Delete the web container registry image"
-        required: true
-        type: boolean
-      workerImage:
-        description: "Delete the worker container registry image"
-        required: true
-        type: boolean
+  pull_request:
+    types: [opened, closed]
+  inputs:
+    image_name:
+      description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
+      required: false
+      type: string
+    tag:
+      required: false
+      type: string
+    webImage:
+      description: "Delete the web container registry image"
+      required: true
+      type: boolean
+    workerImage:
+      description: "Delete the worker container registry image"
+      required: true
+      type: boolean
 
 permissions:
   contents: read
@@ -29,6 +30,7 @@ env:
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
 jobs:
   delete-image:
+    if: ${{ github.event.pull_request.merged = true }}
     runs-on: ubuntu-latest
     steps:
       - id: setup

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -4,10 +4,10 @@ on:
     inputs:
       image_name:
         description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
-        required: true
+        required: false
         type: string
       tag:
-        required: true
+        required: false
         type: string
       webImage:
         description: "Delete the web container registry image"
@@ -54,7 +54,7 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
           token: ${{ secrets.GITHUB_TOKEN }}
           # token: ${{ secrets.PAT }}
-          tag: ${{ inputs.tag }}
+          tag: ${{ env.$TAG }}
       - name: Delete worker image
         if: ${{ inputs.workerImage }}
         uses: bots-house/ghcr-delete-image-action@v1.1.0

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -29,7 +29,7 @@ env:
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
 jobs:
   delete-image:
-    if: ${{ github.event.pull_request.merged = true }}
+    if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
       - id: setup

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -71,8 +71,8 @@ jobs:
           # NOTE: using Personal Access Token
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#granting-additional-permissions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # token: ${{ secrets.PAT }}
+          # token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           tag: ${{ env.TAG }}
       - name: Delete worker image
         if: ${{ inputs.workerImage }}
@@ -84,6 +84,6 @@ jobs:
           # NOTE: using Personal Access Token
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#granting-additional-permissions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # token: ${{ secrets.PAT }}
+          # token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           tag: ${{ env.TAG }}

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -26,7 +26,6 @@ permissions:
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
 jobs:
   if-merged-delete-image:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - id: setup
@@ -43,7 +42,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Delete web image
-        if: ${{ inputs.webImage }}
+        if: ${{ inputs.webImage && github.event.action == 'closed' && github.event.pull_request.merged = true }}
         uses: bots-house/ghcr-delete-image-action@v1.1.0
         with:
           # NOTE: at now only orgs is supported
@@ -56,7 +55,7 @@ jobs:
           # token: ${{ secrets.PAT }}
           tag: ${{ env.$TAG }}
       - name: Delete worker image
-        if: ${{ inputs.workerImage }}
+        if: ${{ inputs.workerImage && github.event.action == 'closed' && github.event.pull_request.merged = true }}
         uses: bots-house/ghcr-delete-image-action@v1.1.0
         with:
           # NOTE: at now only orgs is supported

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           # NOTE: at now only orgs is supported
           owner: scientist-softserv
-          name: ${{ env.REPO_LOWER }}
+          name: ${{ inputs.image_name || github.repository }}
           # NOTE: using Personal Access Token
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#granting-additional-permissions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
@@ -63,7 +63,7 @@ jobs:
         with:
           # NOTE: at now only orgs is supported
           owner: scientist-softserv
-          name: ${{ env.REPO_LOWER }}/worker
+          name: ${{ inputs.image_name || github.repository }}/worker
           # NOTE: using Personal Access Token
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#granting-additional-permissions
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -1,24 +1,22 @@
 name: Cleanup PR Registry Images
 on:
-  pull_request:
-    types:
-      - closed
-  inputs:
-    image_name:
-      description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
-      required: true
-      type: string
-    tag:
-      required: true
-      type: string
-    webImage:
-      description: "Delete the web container registry image"
-      required: true
-      type: boolean
-    workerImage:
-      description: "Delete the worker container registry image"
-      required: true
-      type: boolean
+  workflow_dispatch:
+    inputs:
+      image_name:
+        description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      webImage:
+        description: "Delete the web container registry image"
+        required: true
+        type: boolean
+      workerImage:
+        description: "Delete the worker container registry image"
+        required: true
+        type: boolean
 
 permissions:
   contents: read

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -23,6 +23,9 @@ permissions:
   packages: write
   security-events: write
 
+env:
+  REGISTRY: ghcr.io
+
 # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
 jobs:
   delete-image:

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -1,5 +1,22 @@
 name: Cleanup PR Registry Images
 on:
+  workflow_call:
+    inputs:
+      image_name:
+        description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
+        required: false
+        type: string
+      tag:
+        required: false
+        type: string
+      webImage:
+        description: "Delete the web container registry image"
+        required: true
+        type: boolean
+      workerImage:
+        description: "Delete the worker container registry image"
+        required: true
+        type: boolean
   workflow_dispatch:
     inputs:
       image_name:

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -2,22 +2,22 @@ name: Cleanup PR Registry Images
 on:
   pull_request:
     types: [opened, closed]
-  inputs:
-    image_name:
-      description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
-      required: false
-      type: string
-    tag:
-      required: false
-      type: string
-    webImage:
-      description: "Delete the web container registry image"
-      required: true
-      type: boolean
-    workerImage:
-      description: "Delete the worker container registry image"
-      required: true
-      type: boolean
+    inputs:
+      image_name:
+        description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
+        required: false
+        type: string
+      tag:
+        required: false
+        type: string
+      webImage:
+        description: "Delete the web container registry image"
+        required: true
+        type: boolean
+      workerImage:
+        description: "Delete the worker container registry image"
+        required: true
+        type: boolean
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.11
+        uses: scientist-softserv/actions/setup-env@add-prune-ghcr-images-after-merge-to-main
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.11
+        uses: scientist-softserv/actions/setup-env@add-prune-ghcr-images-after-merge-to-main
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/list-repo-tags.yaml
+++ b/.github/workflows/list-repo-tags.yaml
@@ -1,0 +1,11 @@
+name: List all tagged image versions
+on:
+
+jobs:
+  curl:
+    runs-on: ubuntu-latest
+    steps:
+    - name: curl
+      uses: wei/curl@master
+      with:
+        args: -H "Authorization: Bearer $GITHUB_TOKEN" https://ghcr.io/v2/{$owner}/${repo}/tags/list

--- a/.github/workflows/pr-approved-notification.yaml
+++ b/.github/workflows/pr-approved-notification.yaml
@@ -1,0 +1,12 @@
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  approved:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This PR was approved"
+
+# How can we integrate notifying the individual user that their pr was approved?

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.11
+        uses: scientist-softserv/actions/setup-env@add-prune-ghcr-images-after-merge-to-main
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Test run of this action was run on Adventist, details below:

Test Run: https://github.com/scientist-softserv/adventist-dl/actions/runs/4400538976/jobs/7705928963

Workflow file: https://github.com/scientist-softserv/adventist-dl/actions/runs/4400538976/workflow

Notes: 
Issue 1: `image_name` needed to be set as the repository name. I kept getting org/repo_name and just needed repo_name, so I added it as:
`image_name: adventist-dl`
and that was exactly what I needed to get onto the next error.
Issue 2: The `GITHUB_TOKEN` did not have the permissions of `delete:packages` that was needed in addition to `read:packages`. I ended up adding a Personal Access Token (PAT) with delete:packages and read:packages permissions. Since this is a test run and proof of concept, I set this PAT to expire automatically in 1 month on April 10th 2023.
** We will need to update the PAT with an ORG level PAT (like Jio's) with `delete:packages, read:packages` permissions.
- [ ] Discuss this with Rob to see what the desired path would be and ask him to set it up or give me access if a PAT is needed at ORG level because I can't seem to add one currently. Or ask for instructions on how he added it so I can re-verify I do/don't need his support.
- [ ] Once ready to merge change the `@add-prune-ghcr-images-after-merge-to-main` to the next cut of a release (v0.0.14 maybe?).

<details><summary>SCREENSHOTS DROPDOWN -- CLICK ME</summary>
Screenshot of the PAT created for proof of concept - **note it expires on April 10th 2023 (in 1 month)**
<img width="1117" alt="Screenshot 2023-03-12 at 19 26 08" src="https://user-images.githubusercontent.com/63515648/224596189-411a04e1-e25f-41ae-ae76-62601e6c7d27.png">

Before action screenshots of the web and worker container registry, note the sha's are present.
<img width="1373" alt="Screenshot 2023-03-12 at 18 19 17" src="https://user-images.githubusercontent.com/63515648/224597065-a2a51278-51b1-4010-8c97-d762a84766ed.png">
<img width="1373" alt="Screenshot 2023-03-12 at 18 19 06" src="https://user-images.githubusercontent.com/63515648/224597067-6252ba93-7a7c-49ea-8f9c-60ed5d59c8e9.png">

After action screenshots of the web and worker container registry, note the sha's are not present anymore.
<img width="1371" alt="Screenshot 2023-03-12 at 18 49 20" src="https://user-images.githubusercontent.com/63515648/224596452-4574a87b-fdef-421b-8965-90aaf17bf9fb.png">
<img width="1370" alt="Screenshot 2023-03-12 at 18 41 38" src="https://user-images.githubusercontent.com/63515648/224596726-453c061a-b9b2-442e-a099-9abf0b85c011.png">

</details>