### PR TITLE
yml is picky

### DIFF
--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -38,7 +38,7 @@ runs:
         token: ${{ inputs.token }}
         clean: false
     - name: Make sure env files are present if missing
-       run: >-
-         cd ${{ inputs.subdir }};
-         touch .env.development;
-         touch .env;
+      run: >-
+        cd ${{ inputs.subdir }};
+        touch .env.development;
+        touch .env;


### PR DESCRIPTION
hopefully fix action.yaml

after releasing v0.0.16 with the following commit: a33e25ab51f56f138f586e358c22770b3acdde47 and using v16 in the webstore, we got the following error:
  | Error: scientist-softserv/actions/v0.0.16/setup-env/action.yaml:
  |(Line: 41, Col: 11, Idx: 938) - (Line: 41, Col: 11, Idx: 938): Mapping
  |values are not allowed in this context.

this comment (https://stackoverflow.com/a/70930521/8079848) makes me hope that fixing the spacing will fix the error.