### PR TITLE
add cypress to v16+

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -1,0 +1,134 @@
+name: "Cypress testing"
+on:
+  workflow_dispatch:
+    inputs:
+      confdir:
+        required: false
+        type: string
+        default: "/app/samvera/hyrax-webapp/solr/config"
+      cypress-container-name:
+        required: false
+        type: string
+      subdir:
+        default: '.'
+        type: string
+      tag:
+        required: false
+        type: string
+      rspec_cmd:
+        required: false
+        type: string
+        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
+      setup_db_cmd:
+        required: false
+        type: string
+        default: "RAILS_ENV=test bundle exec rake db:create db:schema:load db:migrate"
+      worker:
+        required: false
+        type: boolean
+  workflow_call:
+    inputs:
+      confdir:
+        required: false
+        type: string
+        default: "/app/samvera/hyrax-webapp/solr/config"
+      cypress-container-name:
+        required: false
+        type: string
+      subdir:
+        default: '.'
+        type: string
+      tag:
+        required: false
+        type: string
+      rspec_cmd:
+        required: false
+        type: string
+        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
+      setup_db_cmd:
+        required: false
+        type: string
+        default: "RAILS_ENV=test bundle exec rake db:create db:schema:load db:migrate"
+      worker:
+        required: false
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    env:
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+      CONFDIR: ${{ inputs.confdir }}
+      DB_CLEANER_ALLOW_REMOTE_DB_URL: "true"
+      TB_RSPEC_FORMATTER: progress
+      TB_RSPEC_OPTIONS: --format RspecJunitFormatter --out rspec.xml
+    steps:
+      - id: setup
+        name: Setup
+        uses: scientist-softserv/actions/setup-env@v0.0.16
+        with:
+          tag: ${{ inputs.tag }}
+          token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Github Container Login
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        with:
+          limit-access-to-actor: true
+      - name: Pull image to prevent build
+        run: >-
+          cd ${{ inputs.subdir }};
+          touch .env.development;
+          touch .env;
+          docker-compose pull web
+      - name: Pull worker image to prevent build
+        if: ${{ inputs.worker }}
+        run: >-
+          cd ${{ inputs.subdir }};
+          docker-compose pull worker
+      - name: Start containers
+        run: >-
+          cd ${{ inputs.subdir }};
+          [ -f "db/schema.rb" ] && chmod 777 db/schema.rb;
+          docker-compose up -d web
+      - name: Check for and setup Solr if needed
+        shell: bash
+        run: |
+          cd ${{ inputs.subdir }};
+          if [ -d solr ]
+          then
+            docker-compose exec -T web sh -c \
+            "solrcloud-upload-configset.sh "${CONFDIR}" &&
+            SOLR_COLLECTION_NAME=hydra-test solrcloud-assign-configset.sh &&
+            solrcloud-assign-configset.sh"
+          else
+            echo "No solr directory found, skipping..."
+          fi
+      - name: Setup db
+        run: >-
+          cd ${{ inputs.subdir }};
+          docker-compose exec -T web sh -c
+          "${{ inputs.setup_db_cmd }}"
+      - name: Run Cypress Tests
+        id: run-specs
+        continue-on-error: true
+        run: >-
+          cd ${{ inputs.subdir }};
+          docker compose up ${{ inputs.cypress-container-name }}
+      - name: Fail job if spec failure
+        run: if [[ ${{ steps.run-specs.outcome }} == "failure" ]]; then exit 1; else exit 0; fi
+      - name: Publish Cypress Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: 'cypress/results/results-*.xml'


### PR DESCRIPTION
make the cypress workflow available for v16+

while debugging a [viva deploy issue](https://assaydepot.slack.com/archives/C0313NK4SMS/p1702324076056739), I tried to update the actions to v16 as a troubleshooting step. cypress isn't included in actions after v14, so I couldn't do that. this workflow is a copy of the one in v14, except that the setup step points to v16.

ref: https://github.com/scientist-softserv/actions/blob/v0.0.14/.github/workflows/cypress.yaml