### PR TITLE
Seperate reports to their own step

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -91,9 +91,10 @@ jobs:
           [ -f "bin/checkout_all.sh" ] && ./bin/checkout_all.sh;
           docker compose pull web || true;
           docker compose run -T web sh -c
-          "${{ inputs.rubocop_cmd }}"
+          "${{ inputs.rubocop_cmd }}"; true
       - name: Archive spec reports
         uses: actions/upload-artifact@v4
+        if: success() || failure()
         with:
           name: rubocop-reports
           path: 'rubocop*.xml'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -95,5 +95,5 @@ jobs:
       - name: Archive spec reports
         uses: actions/upload-artifact@v4
         with:
-          name: spec-reports
+          name: rubocop-reports
           path: 'rubocop*.xml'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -92,8 +92,8 @@ jobs:
           docker compose pull web || true;
           docker compose run -T web sh -c
           "${{ inputs.rubocop_cmd }}"
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        if: always() # always run even if the previous step fails
+      - name: Archive spec reports
+        uses: actions/upload-artifact@v4
         with:
-          report_paths: 'rubocop*.xml'
+          name: spec-reports
+          path: 'rubocop*.xml'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ on:
         required: false
         type: string
       rubocop_cmd:
-        default: bundle exec rubocop --parallel --format progress
+        default: bundle exec rubocop --parallel --format progress --format junit --out rubocop.xml --display-only-failed
         required: false
         type: string
       solrTarget:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -85,13 +85,14 @@ jobs:
         with:
           limit-access-to-actor: true
       - name: Run Rubocop
+        continue-on-error: true
         run: >-
           cd ${{ inputs.subdir }};
           [ -f "db/schema.rb" ] && chmod 777 db/schema.rb;
           [ -f "bin/checkout_all.sh" ] && ./bin/checkout_all.sh;
           docker compose pull web || true;
           docker compose run -T web sh -c
-          "${{ inputs.rubocop_cmd }}"; true
+          "${{ inputs.rubocop_cmd }}"
       - name: Archive spec reports
         uses: actions/upload-artifact@v4
         if: success() || failure()

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -85,7 +85,6 @@ jobs:
         with:
           limit-access-to-actor: true
       - name: Run Rubocop
-        continue-on-error: true
         run: >-
           cd ${{ inputs.subdir }};
           [ -f "db/schema.rb" ] && chmod 777 db/schema.rb;
@@ -95,7 +94,7 @@ jobs:
           "${{ inputs.rubocop_cmd }}"
       - name: Archive spec reports
         uses: actions/upload-artifact@v4
-        if: success() || failure()
+        if: always()
         with:
           name: rubocop-reports
           path: 'rubocop*.xml'

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -1,6 +1,7 @@
 name: "Rspec for Rails Apps"
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   report:

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -5,17 +5,27 @@ on:
 
 jobs:
   report:
+    name: "Publish Lint and Test Results"
+    permissions:
+      checks: write
+      # only needed unless run with comment_mode: off
+      pull-requests: write
+      # only needed for private repository
+      contents: read
+      # only needed for private repository
+      issues: read
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
+        with:
+          path: artifacts
 
         # you need TB_RSPEC_OPTIONS: --format RspecJunitFormatter --out rspec.xml and TB_RSPEC_FORMATTER: progress in your .env for this to work
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        if: success() || failure()
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          report_paths: '**/r*.xml'
-          fail_on_failure: true
-          require_passed_tests: true
-          detailed_summary: true
+          files: "artifacts/**/*.xml"
+          action_fail_on_inconclusive: true
+          fail_on: "test failures"

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -1,0 +1,20 @@
+name: "Rspec for Rails Apps"
+on:
+  workflow_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+
+        # you need TB_RSPEC_OPTIONS: --format RspecJunitFormatter --out rspec.xml and TB_RSPEC_FORMATTER: progress in your .env for this to work
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: success() || failure()
+        with:
+          report_paths: '**/rspec*.xml'
+          fail_on_failure: true
+          require_passed_tests: true
+          detailed_summary: true

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: mikepenz/action-junit-report@v3
         if: success() || failure()
         with:
-          report_paths: '**/rspec*.xml'
+          report_paths: '**/r*.xml'
           fail_on_failure: true
           require_passed_tests: true
           detailed_summary: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL && cp rspec.xml rspec-$CI_NODE_INDEX.xml"
+        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL && mv rspec.xml rspec-$CI_NODE_INDEX.xml"
       setup_db_cmd:
         required: false
         type: string
@@ -53,7 +53,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL && cp rspec.xml rspec-$CI_NODE_INDEX.xml"
+        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL && mv rspec.xml rspec-$CI_NODE_INDEX.xml"
       setup_db_cmd:
         required: false
         type: string

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTA}L; mv rspec.xml rspec-${CI_NODE_INDEX}.xml"
+        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTAL}; mv rspec.xml rspec-${CI_NODE_INDEX}.xml"
       setup_db_cmd:
         required: false
         type: string
@@ -53,7 +53,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTA}L; mv rspec.xml rspec-${CI_NODE_INDEX}.xml"
+        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTAL}; mv rspec.xml rspec-${CI_NODE_INDEX}.xml"
       setup_db_cmd:
         required: false
         type: string

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: "Rspec for Rails Apps"
+same: "Rspec for Rails Apps"
 on:
   workflow_dispatch:
     inputs:
@@ -13,7 +13,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTAL}; mv rspec.xml rspec-${CI_NODE_INDEX}.xml; ls -l"
+        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTAL}"
       setup_db_cmd:
         required: false
         type: string
@@ -53,7 +53,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTAL}; mv rspec.xml rspec-${CI_NODE_INDEX}.xml; ls -l"
+        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTAL}"
       setup_db_cmd:
         required: false
         type: string
@@ -152,11 +152,19 @@ jobs:
           cd ${{ inputs.subdir }};
           docker compose exec -T web sh -c
           "${{ inputs.rspec_cmd }}"
+      - name: Move Test Files
+        if: always()
+        env:
+          # Specifies how many jobs you would like to run in parallel,
+          # used for partitioning
+          CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          # Use the index from matrix as an environment variable
+          CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+        run: >-
+          mv rspec.xml rspec-${CI_NODE_INDEX}.xml
       - name: Archive spec reports
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: spec-reports-${{ matrix.ci_node_index }}
           path: '**/rspec*.xml'
-      - name: Fail job if spec failure
-        run: if [[ ${{ steps.run-specs.outcome }} == "failure" ]]; then exit 1; else exit 0; fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-same: "Rspec for Rails Apps"
+name: "Rspec for Rails Apps"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -148,14 +148,13 @@ jobs:
           CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           # Use the index from matrix as an environment variable
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
-        continue-on-error: true
         run: >-
           cd ${{ inputs.subdir }};
           docker compose exec -T web sh -c
           "${{ inputs.rspec_cmd }}"
       - name: Archive spec reports
         uses: actions/upload-artifact@v4
-        if: success() || failure()
+        if: always()
         with:
           name: spec-reports-${{ matrix.ci_node_index }}
           path: '**/rspec*.xml'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -153,13 +153,8 @@ jobs:
           cd ${{ inputs.subdir }};
           docker compose exec -T web sh -c
           "${{ inputs.rspec_cmd }}"
-
-      # you need TB_RSPEC_OPTIONS: --format RspecJunitFormatter --out rspec.xml and TB_RSPEC_FORMATTER: progress in your .env for this to work
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        if: success() || failure()
+      - name: Archive spec reports
+        uses: actions/upload-artifact@v4
         with:
-          report_paths: '**/rspec*.xml'
-          fail_on_failure: true
-          require_passed_tests: true
-          detailed_summary: true
+          name: spec-reports
+          path: '**/rspec*.xml'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -155,6 +155,7 @@ jobs:
           "${{ inputs.rspec_cmd }}"
       - name: Archive spec reports
         uses: actions/upload-artifact@v4
+        if: success() || failure()
         with:
           name: spec-reports-${{ matrix.ci_node_index }}
           path: '**/rspec*.xml'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTAL}; mv rspec.xml rspec-${CI_NODE_INDEX}.xml"
+        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTAL}; mv rspec.xml rspec-${CI_NODE_INDEX}.xml; ls -l"
       setup_db_cmd:
         required: false
         type: string
@@ -53,7 +53,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTAL}; mv rspec.xml rspec-${CI_NODE_INDEX}.xml"
+        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTAL}; mv rspec.xml rspec-${CI_NODE_INDEX}.xml; ls -l"
       setup_db_cmd:
         required: false
         type: string

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL; mv rspec.xml rspec-$CI_NODE_INDEX.xml"
+        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTA}L; mv rspec.xml rspec-${CI_NODE_INDEX}.xml"
       setup_db_cmd:
         required: false
         type: string
@@ -53,7 +53,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL; mv rspec.xml rspec-$CI_NODE_INDEX.xml"
+        default: "gem install semaphore_test_boosters && rspec_booster --job ${CI_NODE_INDEX}/${CI_NODE_TOTA}L; mv rspec.xml rspec-${CI_NODE_INDEX}.xml"
       setup_db_cmd:
         required: false
         type: string

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -156,5 +156,5 @@ jobs:
       - name: Archive spec reports
         uses: actions/upload-artifact@v4
         with:
-          name: spec-reports-${{ matrix.ci_node_total }}
+          name: spec-reports-${{ matrix.ci_node_index }}
           path: '**/rspec*.xml'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: "Rspec for Rails Apps"
+same: "Rspec for Rails Apps"
 on:
   workflow_dispatch:
     inputs:
@@ -13,7 +13,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
+        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL && cp rspec.xml rspec-$CI_NODE_INDEX.xml"
       setup_db_cmd:
         required: false
         type: string
@@ -53,7 +53,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL"
+        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL && cp rspec.xml rspec-$CI_NODE_INDEX.xml"
       setup_db_cmd:
         required: false
         type: string

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,3 +158,5 @@ jobs:
         with:
           name: spec-reports-${{ matrix.ci_node_index }}
           path: '**/rspec*.xml'
+      - name: Fail job if spec failure
+        run: if [[ ${{ steps.run-specs.outcome }} == "failure" ]]; then exit 1; else exit 0; fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL && mv rspec.xml rspec-$CI_NODE_INDEX.xml"
+        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL; mv rspec.xml rspec-$CI_NODE_INDEX.xml"
       setup_db_cmd:
         required: false
         type: string
@@ -53,7 +53,7 @@ on:
       rspec_cmd:
         required: false
         type: string
-        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL && mv rspec.xml rspec-$CI_NODE_INDEX.xml"
+        default: "gem install semaphore_test_boosters && rspec_booster --job $CI_NODE_INDEX/$CI_NODE_TOTAL; mv rspec.xml rspec-$CI_NODE_INDEX.xml"
       setup_db_cmd:
         required: false
         type: string

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -156,5 +156,5 @@ jobs:
       - name: Archive spec reports
         uses: actions/upload-artifact@v4
         with:
-          name: spec-reports
+          name: spec-reports-${{ matrix.ci_node_total }}
           path: '**/rspec*.xml'


### PR DESCRIPTION
WARNING:
upon upgrading to this version the following changes are required - A new step needs to be added like so (modify needs accordingliny):
```
  reports:
    if: always()
    needs: [rspec-tests, rubocop]
    uses: scientist-softserv/actions/.github/workflows/report.yaml@seperate_reports
```

See https://github.com/scientist-softserv/test_app/actions/runs/8459056328 for an example. We are moving reporting to a single step, making it so lint and spec jobs fail if they fail but the report only fails if the there are no tests or the report job errors. See https://github.com/marketplace/actions/publish-test-results for the new report job.