### PR TITLE
:bug: removes sudo from setup env run command

### DIFF
--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -44,5 +44,5 @@ runs:
         touch .env;
       shell: bash
     - name: Create more disk space # See https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-      run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      run: rm -rf /usr/share/dotnet && rm -rf /opt/ghc && rm -rf "/usr/local/share/boost" && rm -rf "$AGENT_TOOLSDIRECTORY"
       shell: bash


### PR DESCRIPTION
This was causing an error when deploying pals.

```ruby
"Run sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY" /__w/_temp/f7307c65-f24c-404d-a4a2-8e327e69ce19.sh: line 1: sudo: command not found"
```

ref:
- https://github.com/scientist-softserv/palni-palci/actions/runs/8840191966/job/24275038076