### PR TITLE
update-create-more-disk-space-action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.21
+        uses: scientist-softserv/actions/setup-env@update-create-more-disk-space-action
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@update-create-more-disk-space-action
+        uses: scientist-softserv/actions/setup-env@v0.0.22
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}
@@ -133,7 +133,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push base
         if: ${{ inputs.baseTarget != '' }}
-        uses: scientist-softserv/actions/build-and-push@v0.0.21
+        uses: scientist-softserv/actions/build-and-push@v0.0.22
         with:
           type: base
           location: /base
@@ -141,7 +141,7 @@ jobs:
           tags: ${{ steps.meta-base.outputs.tags }}
       - name: Build and push web
         if: ${{ inputs.webTarget != '' }}
-        uses: scientist-softserv/actions/build-and-push@v0.0.21
+        uses: scientist-softserv/actions/build-and-push@v0.0.22
         with:
           type: web
           location: ""
@@ -149,7 +149,7 @@ jobs:
           tags: ${{ steps.meta-base.outputs.tags }}
       - name: Build and push worker
         if: ${{ inputs.workerTarget != '' }}
-        uses: scientist-softserv/actions/build-and-push@v0.0.21
+        uses: scientist-softserv/actions/build-and-push@v0.0.22
         with:
           type: worker
           location: /worker
@@ -157,7 +157,7 @@ jobs:
           tags: ${{ steps.meta-worker.outputs.tags }}
       - name: Build and push solr
         if: ${{ inputs.solrTarget != '' }}
-        uses: scientist-softserv/actions/build-and-push@v0.0.21
+        uses: scientist-softserv/actions/build-and-push@v0.0.22
         with:
           type: solr
           location: /solr

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@update-create-more-disk-space-action
+        uses: scientist-softserv/actions/setup-env@v0.0.22
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.21
+        uses: scientist-softserv/actions/setup-env@update-create-more-disk-space-action
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -102,7 +102,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@update-create-more-disk-space-action
+        uses: scientist-softserv/actions/setup-env@v0.0.22
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -102,7 +102,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.21
+        uses: scientist-softserv/actions/setup-env@update-create-more-disk-space-action
         with:
           tag: ${{ inputs.tag }}
           image_name: ${{ inputs.image_name }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.21
+        uses: scientist-softserv/actions/setup-env@update-create-more-disk-space-action
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@update-create-more-disk-space-action
+        uses: scientist-softserv/actions/setup-env@v0.0.22
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -105,7 +105,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@update-create-more-disk-space-action
+        uses: scientist-softserv/actions/setup-env@v0.0.22
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -105,7 +105,7 @@ jobs:
     steps:
       - id: setup
         name: Setup
-        uses: scientist-softserv/actions/setup-env@v0.0.21
+        uses: scientist-softserv/actions/setup-env@update-create-more-disk-space-action
         with:
           tag: ${{ inputs.tag }}
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/build-and-push/action.yaml
+++ b/build-and-push/action.yaml
@@ -17,11 +17,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # See https://github.com/NASA-IMPACT/hls-base/blob/24b9251d1a09c111eeb148361376d3705b391f28/.github/workflows/build_push_to_ecr.yml
-    # See https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-    - name: Create more disk space
-      run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-      shell: bash
     - name: Build and push ${{ inputs.type }}
       env:
         BUILD_LOCATION: ${{ inputs.location }}

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -43,7 +43,7 @@ runs:
         touch .env.development;
         touch .env;
       shell: bash
-    - name: Create more disk space
+    - name: Create more disk space # See https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
       if: ${{ github.job != 'deployment' }}
       run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       shell: bash

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -43,6 +43,7 @@ runs:
         touch .env.development;
         touch .env;
       shell: bash
-    - name: Create more disk space # See https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+    - name: Create more disk space
+      if: github.job != 'deployment'
       run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       shell: bash

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -44,6 +44,6 @@ runs:
         touch .env;
       shell: bash
     - name: Create more disk space
-      if: github.job != 'deployment'
+      if: ${{ github.job }} != 'deployment'
       run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       shell: bash

--- a/setup-env/action.yaml
+++ b/setup-env/action.yaml
@@ -44,6 +44,6 @@ runs:
         touch .env;
       shell: bash
     - name: Create more disk space
-      if: ${{ github.job }} != 'deployment'
+      if: ${{ github.job != 'deployment' }}
       run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       shell: bash


### PR DESCRIPTION
Remove form the build action since using already (so currently running twice) in the setup-env action
The deploy action's container does not have sudo as a helm container.
So logic excludes the use of the create more space action on the deploy workflow.


Worked: https://github.com/scientist-softserv/atla-hyku/actions/runs/8854077161/job/24316326996
