### PR TITLE
replace debug boolean with dropdown

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_step == 'build' }}
         with:
           limit-access-to-actor: true
       - name: Retag action for base

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -82,7 +82,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_step == 'cypress' }}
         with:
           limit-access-to-actor: true
       - name: Pull image to prevent build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -111,7 +111,7 @@ jobs:
           token: ${{ secrets.CHECKOUT_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_step == 'deploy' }}
         with:
           limit-access-to-actor: true
       - name: Do deploy with solr image

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -81,7 +81,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_step == 'lint' }}
         with:
           limit-access-to-actor: true
       - name: Run Rubocop

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -116,11 +116,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-        with:
-          limit-access-to-actor: true
       - name: Start containers
         run: >-
           cd ${{ inputs.subdir }};
@@ -140,6 +135,11 @@ jobs:
           cd ${{ inputs.subdir }};
           docker compose exec -T web sh -c
           "${{ inputs.setup_db_cmd }}"
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_step == 'test' }}
+        with:
+          limit-access-to-actor: true
       - name: Run Specs
         id: run-specs
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -116,6 +116,11 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_step == 'test' }}
+        with:
+          limit-access-to-actor: true
       - name: Start containers
         run: >-
           cd ${{ inputs.subdir }};
@@ -135,11 +140,6 @@ jobs:
           cd ${{ inputs.subdir }};
           docker compose exec -T web sh -c
           "${{ inputs.setup_db_cmd }}"
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_step == 'test' }}
-        with:
-          limit-access-to-actor: true
       - name: Run Specs
         id: run-specs
         env:


### PR DESCRIPTION
Ref 
- #74

**See it in action:**
- https://github.com/scientist-softserv/palni-palci/pull/1039 

Instead of halting every step in CI when debugging via tmate is enabled, allow the actor to select which step they want to debug.

Previously, if a dev was trying to debug the test step, for example, they would have to first tmate into the build step and close the session to allow the build to proceed.

![Build Test Lint · Workflow runs · scientist-softservpalni-palci 2024-06-21 at 12 41 02 PM](https://github.com/scientist-softserv/actions/assets/32469930/a1b9aadb-90b3-4cdf-9e6c-d805432a2fe0)
